### PR TITLE
Fix incorrect test cases #161

### DIFF
--- a/hydrograph.engine/hydrograph.engine.transformation/src/test/java/hydrograph/engine/transformation/standardfunctions/DateFunctionsTest.java
+++ b/hydrograph.engine/hydrograph.engine.transformation/src/test/java/hydrograph/engine/transformation/standardfunctions/DateFunctionsTest.java
@@ -110,15 +110,16 @@ public class DateFuncitonsTest {
 
     @Test
     public void itShouldReturnLastDateOfMonthFromMonth() throws  ParseException {
-        Date lastDateOfMonthFromMonth= DateFunctions.getLastDateOfMonth(5);
-        String date= new SimpleDateFormat("yyyy-MM-dd").format(lastDateOfMonthFromMonth);
-        Assert.assertEquals(date,"2017-05-31");
+        Date lastDateOfMonthFromMonth = DateFunctions.getLastDateOfMonth(5);
+        String actualDate = new SimpleDateFormat("yyyy-MM-dd").format(lastDateOfMonthFromMonth);
+        String expectedDate = java.time.Year.now() + "-05-31";
+        Assert.assertEquals(actualDate, expectedDate);
     }
 
     @Test
     public void itShouldReturnLastDateOfMonthAndYear() {
-        Date lastDateOfMonthFromMonthAndYear= DateFunctions.getLastDateOfMonthAndYear(5,2017);
-        String date= new SimpleDateFormat("yyyy-MM-dd").format(lastDateOfMonthFromMonthAndYear);
+        Date lastDateOfMonthFromMonthAndYear = DateFunctions.getLastDateOfMonthAndYear(5,2017);
+        String date = new SimpleDateFormat("yyyy-MM-dd").format(lastDateOfMonthFromMonthAndYear);
         Assert.assertEquals(date,"2017-05-31");
     }
 


### PR DESCRIPTION
- Remove hard coded expected value in
hydrograph.engine.transformation.standardfunctions.DateFuncitonsTest. This fixes https://github.com/capitalone/Hydrograph/issues/161
- Also rename the file DateFuncitonsTest.java -> DateFunctionsTest.java